### PR TITLE
Link to the license in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 code here was written by the original GrammaTech developers, but they are not
 responsible for any bugs.
 
-The original project readme follows below.
+The [`LICENSE`](https://github.com/EliahKagan/pylint-sarif/blob/develop/LICENSE)
+is the same as in the upstream project. The original project readme follows
+below.
 
 # pylint-sarif
 


### PR DESCRIPTION
This doesn't matter much for people reading the readme on GitHub, but I think it's helpful for PyPI, where otherwise there is no single-click way that gets the original copyright statement and exact license text.