### PR TITLE
Use Python 3.11 on CI

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install poetry
         run: pipx install poetry


### PR DESCRIPTION
For the job that runs Pylint.

For now, CodeQL still uses its default (Python 3.10).