### PR TITLE
Hold jsonschema at 4.17.* to work around #19

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,29 @@
 code here was written by the original GrammaTech developers, but they are not
 responsible for any bugs.
 
+This is on PyPI as
+[`pylint-sarif-unofficial`](https://pypi.org/project/pylint-sarif-unofficial/).
+
+This does not currently support
+[jsonschema](https://github.com/python-jsonschema/jsonschema) 4.18
+([bug #19](https://github.com/EliahKagan/pylint-sarif/issues/19)). To avoid
+holding your project's `jsonschema` version (if it uses it) back, I suggest
+installing `pylint-sarif-unofficial` using `pipx` instead of listing it in
+your project's manifest file. You can put a command like this in your pylint CI
+workflow:
+
+```bash
+pipx install pylint-sarif-unofficial
+```
+
+Or with the specific version you want, for example:
+
+```bash
+pipx install pylint-sarif-unofficial==0.2.0
+```
+
+Your project can still install `pylint` itself as a development dependency.
+
 The [`LICENSE`](https://github.com/EliahKagan/pylint-sarif/blob/develop/LICENSE)
 is the same as in the upstream project. The original project readme follows
 below.

--- a/poetry.lock
+++ b/poetry.lock
@@ -535,4 +535,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "3db34dc9ff1332067c50035ef43be95c99e5df866f8f15a342a213a35578882d"
+content-hash = "8815d018ddc19b0fa9ccdaeabe7415b4682806125cecd6bf71ff066029607ddf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pylint-sarif-unofficial"
-version = "0.1.0"
+version = "0.2.0a0"
 description = "Pylint output as SARIF"
 authors = []
 maintainers = ["Eliah Kagan <degeneracypressure@gmail.com>"]
@@ -23,6 +23,7 @@ include = ["sarif-schema.json"]  # TODO: Do this better (maybe via data_files).
 
 [tool.poetry.dependencies]
 python = "^3.7"
+jsonschema = "~4.17.3"
 python-jsonschema-objects = "^0.4.2"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
This also updates the readme accordingly, to link #19 and recommend installing via pipx instead of as a dev dependency of a project that might otherwise depend on jsonschema and benefit from using a later version.

It also adds a link to PyPI. This will look a little weird as long as the main (repo root) readme and PyPI readme are the same file, but I think it's better than omitting it, and I don't want to add a badge for it instead until I've thought through what other badges (if any) ought to be shown.